### PR TITLE
allow :query to accept a function returning a query string

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -454,7 +454,9 @@ KAR, or raise an error if none is found."
 		 (mu4e-bookmarks))
 	    (mu4e-warn "Unknown shortcut '%c'" kar)))
 	 (expr (mu4e-bookmark-query chosen-bm))
-	 (query (eval expr)))
+         (expr (if (not (functionp expr)) expr
+                 (funcall expr)))
+         (query (eval expr)))
     (if (stringp query)
       query
       (mu4e-warn "Expression must evaluate to query string ('%S')" expr))))

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -2012,10 +2012,11 @@ defined in the echo area, with the shortcut key highlighted. So, to invoke the
 bookmark we just defined (to get the list of "Big Messages"), all you need to
 type is @kbd{bb}.
 
-@subsection Lisp expressions as bookmarks
+@subsection Lisp expressions or functions as bookmarks
 
 Instead of using strings, it is also possible to use Lisp expressions as
-bookmarks. The only requirement is that they evaluate to a query string.
+bookmarks. Either the expression evaluates to a query string or the expression
+is a function taking no argument that returns a query string.
 
 For example, to get all the messages that are at most a week old in your
 inbox:
@@ -2024,11 +2025,30 @@ inbox:
 (add-to-list 'mu4e-bookmarks
   (make-mu4e-bookmark
    :name  "Inbox messages in the last 7 days"
-   :query (concat "maildir:/inbox AND date:"
+   :query (lambda () (concat "maildir:/inbox AND date:"
              (format-time-string "%Y%m%d"
-                (subtract-time (current-time) (days-to-time 7))))
+                (subtract-time (current-time) (days-to-time 7)))))
    :key ?w) t)
 @end lisp
+
+Another example where the user is prompted how many days old messages should be
+shown:
+
+@lisp
+(defun my/mu4e-bookmark-num-days-old-query (days-old)
+  (interactive (list (read-number "Show days old messages: " 7)))
+  (let ((start-date (subtract-time (current-time) (days-to-time days-old))))
+    (concat "maildir:/inbox AND date:"
+            (format-time-string "%Y%m%d" start-date))))
+
+(add-to-list 'mu4e-bookmarks
+  (make-mu4e-bookmark
+   :name  "Inbox messages in the last 7 days"
+   :query (lambda () (call-interactively 'my/mu4e-bookmark-num-days-old-query))
+   :key ?o) t)
+@end lisp
+
+It is defining a function to make the code more readable.
 
 @subsection Editing bookmarks before searching
 


### PR DESCRIPTION
This allows one to dynamically generate the query string, based for
example on the value of a variable.